### PR TITLE
Fix qualification of zero param methods

### DIFF
--- a/Runtime/Scripts/Scene/BanterScene.cs
+++ b/Runtime/Scripts/Scene/BanterScene.cs
@@ -740,7 +740,7 @@ namespace Banter.SDK
             //         paramsList += MessageDelimiters.PRIMARY;
             //     }
             // }
-            var parameters = msgParts[2].Split(MessageDelimiters.SECONDARY);
+            var parameters = msgParts[2].Split(MessageDelimiters.SECONDARY, StringSplitOptions.RemoveEmptyEntries);
             var paramList = new List<object>();
             foreach (var param in parameters)
             {


### PR DESCRIPTION
Methods like BanterAudioSource.Play() weren't firing from JS land.