### PR TITLE
[DRAFT][ALTSPACE BUILDER] Stop reporting success after upload failures

### DIFF
--- a/Editor/Resources/Builder/BuilderWindow.cs
+++ b/Editor/Resources/Builder/BuilderWindow.cs
@@ -1024,9 +1024,9 @@ public class BuilderWindow : EditorWindow
             {
                 uploadWebOnly.SetEnabled(false);
                 uploadEverything.SetEnabled(false);
-                EditorCoroutineUtility.StartCoroutine(UploadWebOnly(() =>
+                EditorCoroutineUtility.StartCoroutine(UploadWebOnly(succeeded =>
                 {
-                    status.AddStatus("Upload complete.");
+                    status.AddStatus(succeeded ? "Upload complete." : "Upload failed.");
                     uploadWebOnly.SetEnabled(true);
                     uploadEverything.SetEnabled(true);
                 }), this);
@@ -1046,9 +1046,9 @@ public class BuilderWindow : EditorWindow
                 confirmCallback = null;
                 uploadWebOnly.SetEnabled(false);
                 uploadEverything.SetEnabled(false);
-                EditorCoroutineUtility.StartCoroutine(UploadEverything(() =>
+                EditorCoroutineUtility.StartCoroutine(UploadEverything(succeeded =>
                 {
-                    status.AddStatus("Upload complete.");
+                    status.AddStatus(succeeded ? "Upload complete." : "Upload failed.");
                     uploadWebOnly.SetEnabled(true);
                     uploadEverything.SetEnabled(true);
                 }), this);
@@ -1388,14 +1388,21 @@ public class BuilderWindow : EditorWindow
         EndUploadProgress("Upload complete");
     }
 
-    private IEnumerator UploadWebOnly(Action callback)
+    private enum WorldFileUploadResult
     {
-        BeginUploadProgress(3);
-        yield return UploadWorldFile("index.html", UploadAssetType.Index, UploadAssetTypePlatform.Any, NextUploadStep("Uploading index.html"));
-        yield return UploadWorldFile("script.js", UploadAssetType.Js, UploadAssetTypePlatform.Any, NextUploadStep("Uploading script.js"));
-        yield return UploadWorldFile("bullshcript.js", UploadAssetType.Js, UploadAssetTypePlatform.Any, NextUploadStep("Uploading bullshcript.js"));
-        callback();
-        EndUploadProgress("Upload complete");
+        Skipped,
+        Succeeded,
+        Failed
+    }
+
+    private IEnumerator UploadWebOnly(Action<bool> callback)
+    {
+        return UploadWorldFiles(new[]
+        {
+            ("index.html", UploadAssetType.Index),
+            ("script.js", UploadAssetType.Js),
+            ("bullshcript.js", UploadAssetType.Js)
+        }, callback);
     }
     private Texture2D CopyIt(Texture2D source) {
         RenderTexture renderTex = RenderTexture.GetTemporary(
@@ -1497,27 +1504,45 @@ public class BuilderWindow : EditorWindow
             
         }, headers);
     }
-    private IEnumerator UploadEverything(Action callback)
+    private IEnumerator UploadEverything(Action<bool> callback)
     {
-        // callback runs in finally so it always fires — even if an upload step throws — restoring
-        // button state and releasing the assembly-reload lock the scene build hands off (see
-        // BuildAssetBundles). A leaked lock would wedge script recompilation until an editor restart.
+        // One platform-agnostic combined bundle (encrypted Basis .bee content) hosted as asset.world.
+        // Every platform loads this single file and ranged-GETs its own section; the runtime falls back
+        // to legacy per-platform windows.banter / android.banter for spaces that predate it.
+        return UploadWorldFiles(new[]
+        {
+            ("asset.world", UploadAssetType.WorldAsset),
+            ("index.html", UploadAssetType.Index),
+            ("script.js", UploadAssetType.Js),
+            ("bullshcript.js", UploadAssetType.Js)
+        }, callback);
+    }
+
+    private IEnumerator UploadWorldFiles((string name, UploadAssetType type)[] files, Action<bool> callback)
+    {
+        // callback runs in finally so it always restores button state and releases any assembly-reload
+        // lock handed to the upload, including when a nested coroutine throws.
+        bool succeeded = false;
         try
         {
-            BeginUploadProgress(4);
-            // One platform-agnostic combined bundle (encrypted Basis .bee content) hosted as asset.world.
-            // Every platform loads this single file and ranged-GETs its own section; the runtime falls back
-            // to legacy per-platform windows.banter / android.banter for spaces that predate it. Missing
-            // file is skipped.
-            yield return UploadWorldFile("asset.world", UploadAssetType.WorldAsset, UploadAssetTypePlatform.Any, NextUploadStep("Uploading asset.world"));
-            yield return UploadWorldFile("index.html", UploadAssetType.Index, UploadAssetTypePlatform.Any, NextUploadStep("Uploading index.html"));
-            yield return UploadWorldFile("script.js", UploadAssetType.Js, UploadAssetTypePlatform.Any, NextUploadStep("Uploading script.js"));
-            yield return UploadWorldFile("bullshcript.js", UploadAssetType.Js, UploadAssetTypePlatform.Any, NextUploadStep("Uploading bullshcript.js"));
-            EndUploadProgress("Upload complete");
+            BeginUploadProgress(files.Length);
+            foreach (var file in files)
+            {
+                WorldFileUploadResult result = WorldFileUploadResult.Skipped;
+                yield return UploadWorldFile(file.name, file.type, UploadAssetTypePlatform.Any,
+                    NextUploadStep("Uploading " + file.name), value => result = value);
+                if (result == WorldFileUploadResult.Failed)
+                {
+                    yield break;
+                }
+            }
+
+            succeeded = true;
         }
         finally
         {
-            callback?.Invoke();
+            EndUploadProgress(succeeded ? "Upload complete" : "Upload failed");
+            callback?.Invoke(succeeded);
         }
     }
 
@@ -1550,7 +1575,7 @@ public class BuilderWindow : EditorWindow
 
     // Uploads a WebRoot file and attaches it to the selected world (asset.world, index.html, script.js…),
     // via /v2/worlds/{worlds_id}/assets/type/{type}/platform/{platform}. Callers pass platform Any (0).
-    private IEnumerator UploadWorldFile(string name, UploadAssetType type, UploadAssetTypePlatform platform, Action<float> onProgress = null)
+    private IEnumerator UploadWorldFile(string name, UploadAssetType type, UploadAssetTypePlatform platform, Action<float> onProgress = null, Action<WorldFileUploadResult> onCompleted = null)
     {
         var file = Path.Join(Path.Join(assetBundleRoot, assetBundleDirectory), name);
         if (File.Exists(file))
@@ -1560,19 +1585,23 @@ public class BuilderWindow : EditorWindow
         else
         {
             status.AddStatus("File not found, skipping: " + file);
+            onCompleted?.Invoke(WorldFileUploadResult.Skipped);
             yield break;
         }
         var data = File.ReadAllBytes(file);
         string slug = SelectedWorldSlug;
         string baseUrl = string.IsNullOrEmpty(SelectedWorldUrl) ? ("https://" + slug + ".worldspace.host") : SelectedWorldUrl;
+        WorldFileUploadResult result = WorldFileUploadResult.Failed;
         yield return sq.UploadFileToWorld(name, data, selectedWorld?.WorldId, slug, (text) =>
         {
             status.AddStatus("Uploaded " + file + " to " + baseUrl + "/" + name);
+            result = WorldFileUploadResult.Succeeded;
         }, e =>
         {
             status.AddStatus("FAILED UPLOADING " + file + " to " + baseUrl + "/" + name);
             Debug.LogException(e);
         }, type, platform, onProgress);
+        onCompleted?.Invoke(result);
     }
 
     public void Remove(VisualElement element)
@@ -2388,9 +2417,9 @@ public class BuilderWindow : EditorWindow
                         // the upload is done rather than mid-flight.
                         bool unlockAfterUpload = reloadLockHeld;
                         lockHandedToUpload = reloadLockHeld;
-                        EditorCoroutineUtility.StartCoroutine(UploadEverything(() =>
+                        EditorCoroutineUtility.StartCoroutine(UploadEverything(succeeded =>
                         {
-                            status.AddStatus("Upload complete.");
+                            status.AddStatus(succeeded ? "Upload complete." : "Upload failed.");
                             uploadWebOnly.SetEnabled(true);
                             uploadEverything.SetEnabled(true);
                             if (unlockAfterUpload) EditorApplication.UnlockReloadAssemblies();

--- a/Editor/Resources/Builder/SideQuest/SqEditorAppApi.cs
+++ b/Editor/Resources/Builder/SideQuest/SqEditorAppApi.cs
@@ -550,7 +550,12 @@ namespace BS.SDKEditor
                 yield break;
             }
 
-            yield return UploadFileInternal(_uploadRequest, data, name, (text) => { }, OnError, OnProgress);
+            bool uploadSucceeded = false;
+            yield return UploadFileInternal(_uploadRequest, data, name, (text) => uploadSucceeded = true, OnError, OnProgress);
+            if (!uploadSucceeded)
+            {
+                yield break;
+            }
 
             yield return AttachToCommmunity(() => OnCompleted?.Invoke(_uploadRequest), OnError, _uploadRequest.CommunitiesId ?? 0, _uploadRequest.FileId, name, assetType, assetPlatform);
         }
@@ -571,7 +576,12 @@ namespace BS.SDKEditor
                 yield break;
             }
 
-            yield return UploadFileInternal(_uploadRequest, data, name, (text) => { }, OnError, OnProgress);
+            bool uploadSucceeded = false;
+            yield return UploadFileInternal(_uploadRequest, data, name, (text) => uploadSucceeded = true, OnError, OnProgress);
+            if (!uploadSucceeded)
+            {
+                yield break;
+            }
 
             yield return AttachToWorld(() => OnCompleted?.Invoke(_uploadRequest), OnError, worldsId, _uploadRequest.FileId, name, assetType, assetPlatform);
         }
@@ -588,8 +598,12 @@ namespace BS.SDKEditor
                 yield break;
             }
 
-            yield return UploadFileInternal(_uploadRequest, data, name, (text) => { }, OnError, OnProgress);
-            OnCompleted?.Invoke(_uploadRequest);
+            bool uploadSucceeded = false;
+            yield return UploadFileInternal(_uploadRequest, data, name, (text) => uploadSucceeded = true, OnError, OnProgress);
+            if (uploadSucceeded)
+            {
+                OnCompleted?.Invoke(_uploadRequest);
+            }
 
         }
 


### PR DESCRIPTION
## Draft status

This is intentionally a **draft PR** for the Altspace Builder / Creator SDK only. It is not ready to merge until the failure-path behavior is reviewed and exercised in Unity.

Closes #165.
Relates to #167.

## Problem

The nested upload coroutines report errors through callbacks, but their callers do not retain a success/failure result. As a result:

- `UploadFileToWorld` can continue to the attach request after the byte upload fails.
- Generic `UploadFile` can invoke its success callback after the byte upload fails.
- `UploadEverything` and `UploadWebOnly` can still display `Upload complete.` after a required upload or attach step fails.

## Changes

- Stop community, world, and generic upload callers when `UploadFileInternal` does not invoke its success callback.
- Carry `Skipped`, `Succeeded`, and `Failed` outcomes from each world file into the aggregate upload operation.
- Stop the remaining file sequence on a failed upload or attach step.
- Report aggregate success or failure explicitly to all Builder UI callers.
- Keep deliberately absent optional WebRoot files as `Skipped`, preserving existing behavior.
- Complete progress cleanup and restore button/reload-lock state through `finally` on success, failure, or an exception.

## Existing-fix audit

Checked before opening this PR:

- Base is `feature/greenfield` at `f7dffe45b228` (`com.sidequest.creator-sdk` 4.0.0 source).
- Registry `latest` is 3.2.17, which also contains the issue.
- Searched 79 official remote branches/tags and all 150 available PR heads; no equivalent failure-propagation fix was found.
- Merged PR #157 and open PR #159 improve upload transport but retain the unconditional caller/aggregate completion behavior.

## Validation

Passed:

- Roslyn syntax parse of both changed C# files: zero syntax errors.
- `git diff --check`.
- Manual call-site audit for every `UploadEverything`, `UploadWebOnly`, and `UploadWorldFile` invocation.

Not yet proven:

- Full Unity compile. The available Unity 6000.3.10f1 probe is below the Greenfield project's 6000.3.21f1 and current source also requires its matching embedded Basis packages. The probe stops on existing `BasisContentVersion` and UI Toolkit API mismatches outside these edited files.
- Forced upload failure, forced attach failure, and successful hosted upload in the current Builder UI.
- Physical Quest hosted-world behavior; that remains a separate rollout check in #167.

## Scope

Only these Altspace Builder files are changed:

- `Editor/Resources/Builder/SideQuest/SqEditorAppApi.cs`
- `Editor/Resources/Builder/BuilderWindow.cs`

No API, Greenfield client, cache format, world-specific, account-specific, or device-specific change is included.